### PR TITLE
Silence warning about __FILE__ and __LINE__ under ruby 2.7

### DIFF
--- a/lib/pry-stack_explorer.rb
+++ b/lib/pry-stack_explorer.rb
@@ -3,6 +3,7 @@
 
 require "pry" unless defined?(::Pry)
 require "pry-stack_explorer/version"
+require "pry-stack_explorer/location_helper"
 require "pry-stack_explorer/commands"
 require "pry-stack_explorer/frame_manager"
 require "pry-stack_explorer/when_started_hook"

--- a/lib/pry-stack_explorer/commands.rb
+++ b/lib/pry-stack_explorer/commands.rb
@@ -55,7 +55,7 @@ module PryStackExplorer
       sig = meth_obj ? "<#{signature_with_owner(meth_obj)}>" : ""
 
       self_clipped = "#{Pry.view_clip(b_self)}"
-      path = "@ #{b.eval('__FILE__')}:#{b.eval('__LINE__')}"
+      path = "@ #{LocationHelper.source_file(b)}:#{LocationHelper.source_line(b)}"
 
       if !verbose
         "#{type} #{desc} #{sig}"

--- a/lib/pry-stack_explorer/location_helper.rb
+++ b/lib/pry-stack_explorer/location_helper.rb
@@ -1,0 +1,19 @@
+module PryStackExplorer
+  # Ruby 2.6 introduced Binding.source_location, and Ruby 2.7 made it a warning
+  # to eval __FILE__ or __LINE__. This file exists to handle getting the file or
+  # line number silently regardless of ruby version.
+  module LocationHelper
+
+    module_function
+    def source_file(b = binding)
+      return b.source_location.first if b.respond_to?(:source_location)
+      b.eval("__FILE__")
+    end
+
+    module_function
+    def source_line(b = binding)
+      return b.source_location[1] if b.respond_to?(:source_location)
+      b.eval("__LINE__")
+    end
+  end
+end

--- a/lib/pry-stack_explorer/when_started_hook.rb
+++ b/lib/pry-stack_explorer/when_started_hook.rb
@@ -60,7 +60,7 @@ module PryStackExplorer
 
     # remove pry-nav / pry-debugger / pry-byebug frames
     def remove_debugger_frames(bindings)
-      bindings.drop_while { |b| b.eval("__FILE__") =~ /pry-(?:nav|debugger|byebug)/ }
+      bindings.drop_while { |b| LocationHelper.source_file(b) =~ /pry-(?:nav|debugger|byebug)/ }
     end
 
     # binding.pry frame


### PR DESCRIPTION

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
I've opened a PR to merge this upstream, but as time is of the essence, I also did so here on this fork.

The issue is that you can't eval `__FILE__` or `__LINE__` anymore in ruby 2.7+ without getting a warning; the proper way is to call `binding.source_location`, which only became available in 2.6 . So, this adds a helper module that wraps up some of the logic to figure out the safe way to make the call, and replaces the three places where `__LINE__` or `__FILE__` was called with calls to the module.

Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

Upstream PR https://github.com/pry/pry-stack_explorer/pull/48 
https://github.com/inspec/inspec/issues/5042

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed. *NOTE* upstream tests are busted
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
